### PR TITLE
Adding .gitignore file for build files

### DIFF
--- a/root/.gitignore
+++ b/root/.gitignore
@@ -1,0 +1,2 @@
+_vendor/*
+<%= project_name %>


### PR DESCRIPTION
- Ignoring the Gom created `_vendor` folder
- Ignoring the Gom created `<%= project_name %>` executable file
